### PR TITLE
fix: remove the redundant pebble check

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -15,13 +15,6 @@ services:
     override: replace
     command: openfga run
     startup: disabled
-checks:
-  up:
-    override: replace
-    level: alive
-    exec:
-      command: grpc_health_probe -addr localhost:8081
-
 
 parts:
   openfga:


### PR DESCRIPTION
This pull request aims to remove the redundant pebble check. This to-be-removed check is duplicated in the openfga charm and will cause problem if the openfga is enabled with TLS.